### PR TITLE
Support other hosting services

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinCommonCompilerArguments">
-    <option name="apiVersion" value="1.2" />
-    <option name="languageVersion" value="1.2" />
+    <option name="apiVersion" value="1.3" />
+    <option name="languageVersion" value="1.3" />
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.31'
+    ext.kotlin_version = '1.3.21'
     ext.powermock_version = '1.6.4'
     repositories {
         mavenCentral()
@@ -48,8 +48,10 @@ repositories {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    testCompile 'junit:junit:4.12'
-    testCompile "io.mockk:mockk:1.8.6"
+
+    testImplementation "io.mockk:mockk:1.8.6"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.3.0"
+    testRuntime "org.junit.jupiter:junit-jupiter-engine:5.3.0"
 }
 
 sourceSets {
@@ -59,6 +61,21 @@ sourceSets {
 test {
     testLogging {
         showStandardStreams = true
+    }
+}
+
+compileKotlin {
+    kotlinOptions {
+        freeCompilerArgs = ["-Xjsr305=strict"]
+        jvmTarget = "1.8"
+        javaParameters = true
+    }
+}
+compileTestKotlin {
+    kotlinOptions {
+        freeCompilerArgs = ["-Xjsr305=strict"]
+        jvmTarget = "1.8"
+        javaParameters = true
     }
 }
 

--- a/src/main/kotlin/com/github/shiraji/Extensions.kt
+++ b/src/main/kotlin/com/github/shiraji/Extensions.kt
@@ -1,6 +1,5 @@
 package com.github.shiraji
 
-import git4idea.GitCommit
 import java.math.BigInteger
 import java.security.MessageDigest
 

--- a/src/main/kotlin/com/github/shiraji/Extensions.kt
+++ b/src/main/kotlin/com/github/shiraji/Extensions.kt
@@ -7,10 +7,6 @@ import java.security.MessageDigest
 
 fun String.toMd5() = BigInteger(1, MessageDigest.getInstance("MD5").digest(this.toByteArray())).toString(16)
 
+fun String.toSHA1() = BigInteger(1, MessageDigest.getInstance("SHA-1").digest(this.toByteArray())).toString(16)
+
 fun String.subtract(text: String) = this.replace(text, "")
-
-fun GitCommit.getPullRequestNumber() = "Merge pull request #(\\d*)".toRegex().find(this.fullMessage)!!.groups[1]!!.value.toInt()
-
-fun GitCommit.getPullRequestNumberFromSquashCommit() = ".*\\(#(\\d*)\\)".toRegex().find(this.fullMessage)!!.groups[1]!!.value.toInt()
-
-fun GitCommit.isSquashPullRequestCommit() = ".*\\(#(\\d*)\\)".toRegex().containsMatchIn(this.fullMessage)

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/action/FindPullRequestAction.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/action/FindPullRequestAction.kt
@@ -1,31 +1,24 @@
 package com.github.shiraji.findpullrequest.action
 
 import com.github.shiraji.findpullrequest.exceptions.NoPullRequestFoundException
-import com.github.shiraji.findpullrequest.helper.showErrorNotification
 import com.github.shiraji.findpullrequest.helper.showInfoNotification
-import com.github.shiraji.findpullrequest.model.FindPullRequestModel
+import com.github.shiraji.findpullrequest.model.FindPullRequestHostingServices
+import com.github.shiraji.findpullrequest.model.getHosting
 import com.github.shiraji.findpullrequest.model.isDebugMode
-import com.github.shiraji.findpullrequest.model.isJumpToFile
 import com.intellij.ide.BrowserUtil
 import com.intellij.ide.util.PropertiesComponent
-import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.vcs.VcsException
-import com.intellij.openapi.vfs.VirtualFile
-import git4idea.GitUtil
-import git4idea.repo.GitRepository
 import java.net.URLEncoder
 
 class FindPullRequestAction : BaseFindPullRequestAction() {
     override fun actionPerformForNoPullRequestFount(e: AnActionEvent, ex: NoPullRequestFoundException, url: String) {
         val project: Project = e.getData(CommonDataKeys.PROJECT) ?: return
         val config = PropertiesComponent.getInstance(project) ?: return
-        val message = StringBuilder("Could not find the pull request. <a href=\"$url\">Open the commit page</a> ")
+        val message = StringBuilder("Could not find the ${FindPullRequestHostingServices.findBy(config.getHosting()).pullRequestName.toLowerCase()}. <a href=\"$url\">Open the commit page</a> ")
         if (config.isDebugMode()) {
-            val title = URLEncoder.encode("Could not find the pull request", "UTF-8")
+            val title = URLEncoder.encode("Could not find the ${FindPullRequestHostingServices.findBy(config.getHosting()).pullRequestName.toLowerCase()}", "UTF-8")
             val encodedMessage = URLEncoder.encode(ex.detailMessage, "UTF-8")
             message.append("or <a href=\"https://github.com/shiraji/find-pull-request/issues/new?title=$title&body=$encodedMessage\">Submit Issue</a>")
         }
@@ -36,4 +29,11 @@ class FindPullRequestAction : BaseFindPullRequestAction() {
         BrowserUtil.open(url)
     }
 
+    override fun update(e: AnActionEvent?) {
+        e ?: return
+        super.update(e)
+        val project: Project = e.getData(CommonDataKeys.PROJECT) ?: return
+        val config = PropertiesComponent.getInstance(project) ?: return
+        e.presentation.text = "Find ${FindPullRequestHostingServices.findBy(config.getHosting()).pullRequestName}"
+    }
 }

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/action/FindPullRequestCopyAction.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/action/FindPullRequestCopyAction.kt
@@ -2,6 +2,8 @@ package com.github.shiraji.findpullrequest.action
 
 import com.github.shiraji.findpullrequest.exceptions.NoPullRequestFoundException
 import com.github.shiraji.findpullrequest.helper.showInfoNotification
+import com.github.shiraji.findpullrequest.model.FindPullRequestHostingServices
+import com.github.shiraji.findpullrequest.model.getHosting
 import com.github.shiraji.findpullrequest.model.isDebugMode
 import com.github.shiraji.findpullrequest.model.isPopupAfterCopy
 import com.intellij.ide.util.PropertiesComponent
@@ -30,9 +32,9 @@ class FindPullRequestCopyAction : BaseFindPullRequestAction() {
     override fun actionPerformForNoPullRequestFount(e: AnActionEvent, ex: NoPullRequestFoundException, url: String) {
         val project: Project = e.getData(CommonDataKeys.PROJECT) ?: return
         val config = PropertiesComponent.getInstance(project) ?: return
-        val message = StringBuilder("Could not find the pull request. <a href=\"$url\">Copy the commit URL</a> ")
+        val message = StringBuilder("Could not find the ${FindPullRequestHostingServices.findBy(config.getHosting()).pullRequestName.toLowerCase()}. <a href=\"$url\">Copy the commit URL</a> ")
         if (config.isDebugMode()) {
-            val title = URLEncoder.encode("Could not find the pull request", "UTF-8")
+            val title = URLEncoder.encode("Could not find the ${FindPullRequestHostingServices.findBy(config.getHosting()).pullRequestName.toLowerCase()}", "UTF-8")
             val encodedMessage = URLEncoder.encode(ex.detailMessage, "UTF-8")
             message.append("or <a href=\"https://github.com/shiraji/find-pull-request/issues/new?title=$title&body=$encodedMessage\">Submit Issue</a>")
         }
@@ -56,6 +58,14 @@ class FindPullRequestCopyAction : BaseFindPullRequestAction() {
 
     private fun copy(text: String) {
         CopyPasteManager.getInstance().setContents(TextTransferable(text))
+    }
+
+    override fun update(e: AnActionEvent?) {
+        e ?: return
+        super.update(e)
+        val project: Project = e.getData(CommonDataKeys.PROJECT) ?: return
+        val config = PropertiesComponent.getInstance(project) ?: return
+        e.presentation.text = "Copy ${FindPullRequestHostingServices.findBy(config.getHosting()).pullRequestName} URL"
     }
 
 }

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/menu/FindPullRequestMenu.form
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/menu/FindPullRequestMenu.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="root" layout-manager="GridLayoutManager" row-count="7" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="692" height="400"/>
+      <xy x="20" y="20" width="737" height="400"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -37,7 +37,7 @@
           <text value="Jump to File when PR page open"/>
         </properties>
       </component>
-      <grid id="ae4af" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="ae4af" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -47,13 +47,13 @@
         <children>
           <component id="ef8bc" class="javax.swing.JComboBox" binding="protocols">
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
           <component id="e3910" class="javax.swing.JLabel">
             <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Protocol:"/>
@@ -61,11 +61,25 @@
           </component>
           <component id="c75d9" class="javax.swing.JLabel">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <requestFocusEnabled value="true"/>
-              <text value="This setting is for the repository which is hosted at GitHub Enterprise and its procotol is http"/>
+              <text value="This setting is for the repository which is hosted on your server and its procotol is http"/>
+            </properties>
+          </component>
+          <component id="e6a94" class="javax.swing.JComboBox" binding="hostingService">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+          </component>
+          <component id="4ef3e" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Hosting Service:"/>
             </properties>
           </component>
         </children>
@@ -80,10 +94,4 @@
       </component>
     </children>
   </grid>
-  <buttonGroups>
-    <group name="disableRadioButton" bound="true">
-      <member id="a6fb7"/>
-      <member id="660d8"/>
-    </group>
-  </buttonGroups>
 </form>

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/model/FindPullRequestConfig.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/model/FindPullRequestConfig.kt
@@ -9,6 +9,7 @@ private const val DEBUG_MODE = "com.github.shiraji.findpullrequest.model.FindPul
 private const val JUMP_TO_FILE = "com.github.shiraji.findpullrequest.model.FindPullRequestConfig.JUMP_TO_FILE"
 private const val PROTOCOL = "com.github.shiraji.findpullrequest.model.FindPullRequestConfig.PROTOCOL"
 private const val POPUP_AFTER_COPY = "com.github.shiraji.findpullrequest.model.FindPullRequestConfig.POPUP_AFTER_COPY"
+private const val HOSTING = "com.github.shiraji.findpullrequest.model.FindPullRequestConfig.HOSTING"
 
 fun PropertiesComponent.isDisable() = getBoolean(DISABLE, false)
 fun PropertiesComponent.setDisable(value: Boolean) = setValue(DISABLE, value, false)
@@ -24,3 +25,7 @@ fun PropertiesComponent.setProtocol(value: String) = setValue(PROTOCOL, value, "
 
 fun PropertiesComponent.isPopupAfterCopy() = getBoolean(POPUP_AFTER_COPY, false)
 fun PropertiesComponent.setPopupAfterCopy(value: Boolean) = setValue(POPUP_AFTER_COPY, value, false)
+
+fun PropertiesComponent.hasHostingConfig() = getValue(HOSTING) != null
+fun PropertiesComponent.getHosting() = getValue(HOSTING, "")
+fun PropertiesComponent.setHosting(hostingServices: FindPullRequestHostingServices) = setValue(HOSTING, hostingServices.name)

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/model/FindPullRequestHostingServices.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/model/FindPullRequestHostingServices.kt
@@ -1,0 +1,32 @@
+package com.github.shiraji.findpullrequest.model
+
+import com.github.shiraji.subtract
+import com.github.shiraji.toMd5
+import com.github.shiraji.toSHA1
+import com.intellij.openapi.vcs.annotate.FileAnnotation
+import git4idea.repo.GitRepository
+
+enum class FindPullRequestHostingServices(val defaultMergeCommitMessage: Regex, val squashCommitMessage: Regex, val urlPathFormat: String, val commitPathFormat: String, val pullRequestName: String) {
+    GitHub("Merge pull request #(\\d*)".toRegex(), ".*\\(#(\\d*)\\)".toRegex(), "pull/%d/files", "%s/commit/%s", "Pull Request"),
+    GitLab("See merge request .*!(\\d*)".toRegex(), "See merge request .*!(\\d*)".toRegex(), "merge_requests/%d/diffs", "%s/commit/%s", "Merge Request"),
+    Bitbucket("\\(pull request #(\\d*)\\)".toRegex(), "\\(pull request #(\\d*)\\)".toRegex(), "pull-requests/%d/diff", "%s/commits/%s", "Pull Request"),
+
+    ;
+
+    companion object {
+        @JvmStatic
+        fun findBy(name: String): FindPullRequestHostingServices {
+            return values().firstOrNull { it.name == name } ?: GitHub
+        }
+    }
+
+    fun createFileAnchorValue(repository: GitRepository, annotate: FileAnnotation): String? {
+        val projectDir = repository.project.baseDir.canonicalPath?.plus("/") ?: return null
+        val filePath = annotate.file?.canonicalPath?.subtract(projectDir) ?: return null
+        return when (this) {
+            GitHub -> "#diff-${filePath.toMd5()}"
+            GitLab -> "#${filePath.toSHA1()}"
+            Bitbucket -> "#chg-$filePath"
+        }
+    }
+}

--- a/src/test/kotlin/com/github/shiraji/ExtensionsKtTest.kt
+++ b/src/test/kotlin/com/github/shiraji/ExtensionsKtTest.kt
@@ -1,0 +1,25 @@
+package com.github.shiraji
+
+import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Test
+
+class ExtensionsKtTest {
+    @Test
+    fun `Should generate md5`() {
+        val text = "aaa"
+        assertEquals("47bce5c74f589f4867dbd57e9ca9f808", text.toMd5())
+    }
+
+    @Test
+    fun toSHA1() {
+        val text = "aaa"
+        assertEquals("7e240de74fb1ed08fa08d38063f6a6a91462a815", text.toSHA1())
+    }
+
+    @Test
+    fun subtract() {
+        val text = "aaabbbccc"
+        assertEquals("aaaccc", text.subtract("bbb"))
+    }
+
+}

--- a/src/test/kotlin/com/github/shiraji/findpullrequest/model/FindPullRequestHostingServicesTest.kt
+++ b/src/test/kotlin/com/github/shiraji/findpullrequest/model/FindPullRequestHostingServicesTest.kt
@@ -1,0 +1,86 @@
+package com.github.shiraji.findpullrequest.model
+
+import com.github.shiraji.subtract
+import com.github.shiraji.toSHA1
+import com.intellij.openapi.vcs.annotate.FileAnnotation
+import git4idea.repo.GitRepository
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class FindPullRequestHostingServicesTest {
+
+    @Nested
+    inner class createFileAnchorValue {
+        @Test
+        fun `Should create GitHub style of file anchor`() {
+
+            val repository: GitRepository = mockk()
+            every { repository.project.baseDir.canonicalPath } returns ""
+
+            val annotate: FileAnnotation = mockk()
+            every { annotate.file?.canonicalPath?.subtract("") } returns "aaa"
+
+            val got = FindPullRequestHostingServices.GitHub.createFileAnchorValue(repository, annotate)
+
+            assertEquals("#diff-47bce5c74f589f4867dbd57e9ca9f808", got)
+        }
+
+        @Test
+        fun `Should create GitLab style of file anchor`() {
+
+            val repository: GitRepository = mockk()
+            every { repository.project.baseDir.canonicalPath } returns ""
+
+            val annotate: FileAnnotation = mockk()
+            every { annotate.file?.canonicalPath?.subtract("") } returns "aaa"
+
+            val got = FindPullRequestHostingServices.GitLab.createFileAnchorValue(repository, annotate)
+
+            assertEquals("#7e240de74fb1ed08fa08d38063f6a6a91462a815", got)
+        }
+
+        @Test
+        fun `Should create Bitbucket style of file anchor`() {
+
+            val repository: GitRepository = mockk()
+            every { repository.project.baseDir.canonicalPath } returns ""
+
+            val annotate: FileAnnotation = mockk()
+            every { annotate.file?.canonicalPath?.subtract("") } returns "aaa"
+
+            val got = FindPullRequestHostingServices.Bitbucket.createFileAnchorValue(repository, annotate)
+
+            assertEquals("#chg-aaa", got)
+        }
+    }
+
+    @Nested
+    inner class findBy {
+        @Test
+        fun `Should find GitHub if arg is GitHub`() {
+            val text = "GitHub"
+            assertEquals(FindPullRequestHostingServices.GitHub, FindPullRequestHostingServices.findBy(text))
+        }
+
+        @Test
+        fun `Should find GitLab if arg is GitLab`() {
+            val text = "GitLab"
+            assertEquals(FindPullRequestHostingServices.GitLab, FindPullRequestHostingServices.findBy(text))
+        }
+
+        @Test
+        fun `Should find Bitbucket if arg is Bitbucket`() {
+            val text = "Bitbucket"
+            assertEquals(FindPullRequestHostingServices.Bitbucket, FindPullRequestHostingServices.findBy(text))
+        }
+
+        @Test
+        fun `Should find GitHub if arg is invalid`() {
+            val text = ""
+            assertEquals(FindPullRequestHostingServices.GitHub, FindPullRequestHostingServices.findBy(text))
+        }
+    }
+}

--- a/src/test/kotlin/com/github/shiraji/model/FindPullRequestModelTest.kt
+++ b/src/test/kotlin/com/github/shiraji/model/FindPullRequestModelTest.kt
@@ -2,11 +2,13 @@ package com.github.shiraji.model
 
 import com.github.shiraji.findpullrequest.exceptions.NoPullRequestFoundException
 import com.github.shiraji.findpullrequest.model.*
+import com.github.shiraji.subtract
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.SelectionModel
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vcs.annotate.FileAnnotation
 import com.intellij.openapi.vcs.changes.Change
 import com.intellij.openapi.vcs.changes.ChangeListManager
 import com.intellij.openapi.vcs.history.VcsRevisionNumber
@@ -69,6 +71,9 @@ class FindPullRequestModelTest {
     @MockK
     lateinit var virtualRoot: VirtualFile
 
+    @MockK
+    lateinit var fileAnnotation: FileAnnotation
+
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
@@ -123,11 +128,12 @@ class FindPullRequestModelTest {
         }
     }
 
-    private fun mockConfig(isDisable: Boolean = false, isDebugMode: Boolean = false, isJumpToFile: Boolean = true, protocol: String = "https://") {
+    private fun mockConfig(isDisable: Boolean = false, isDebugMode: Boolean = false, isJumpToFile: Boolean = true, protocol: String = "https://", hostingServices: String = "GitHub") {
         every { conf.isDisable() } returns isDisable
         every { conf.isDebugMode() } returns isDebugMode
         every { conf.isJumpToFile() } returns isJumpToFile
         every { conf.getProtocol() } returns protocol
+        every { conf.getHosting() } returns hostingServices
     }
 
     private fun mockProject(isDisposed: Boolean = false) {
@@ -148,13 +154,19 @@ class FindPullRequestModelTest {
                     any(),
                     any(),
                     any(),
-                    any(),
                     any())
         } returns closestPRCommits
 
         every {
             GitHistoryUtils.history(project, virtualRoot, any())
         } returns mergeCommits
+    }
+
+    private fun mockFileAnnotation(filePath: String = "README.md") {
+        val baseDir = ""
+        every { gitRepository.project.baseDir.canonicalPath?.plus("/") } returns baseDir
+        every { gitRepository.vcs?.annotationProvider?.annotate(virtualFile) } returns fileAnnotation
+        every { fileAnnotation.file?.canonicalPath?.subtract(baseDir) } returns filePath
     }
 
     @Test
@@ -167,9 +179,10 @@ class FindPullRequestModelTest {
         mockGitRepository(listOf(generateGitRemote()))
         mockHistory(closestPRCommits = listOf(prCommit1), mergeCommits = listOf(prCommit1, prCommit2, prCommit3))
         mockRevisionNumber(HASH)
+        mockFileAnnotation()
 
         val path = model.createPullRequestPath(gitRepository, vcsRevisionNumber)
-        assertEquals("pull/$PR_NUMBER/files", path)
+        assertEquals("pull/$PR_NUMBER/files#diff-4c6e90faac2675aa89e2176d2eec7d8", path)
     }
 
     @Test
@@ -179,9 +192,10 @@ class FindPullRequestModelTest {
         mockConfig()
         mockGitRepository(listOf(generateGitRemote()))
         mockHistory(closestPRCommits = emptyList(), mergeCommits = listOf(prCommit1))
+        mockFileAnnotation()
 
         val path = model.createPullRequestPath(gitRepository, vcsRevisionNumber)
-        assertEquals("pull/$PR_NUMBER/files", path)
+        assertEquals("pull/$PR_NUMBER/files#diff-4c6e90faac2675aa89e2176d2eec7d8", path)
     }
 
     @Test(expected = NoPullRequestFoundException::class)
@@ -206,12 +220,12 @@ class FindPullRequestModelTest {
         mockGitRepository(listOf(generateGitRemote()))
         mockkStatic(GitHistoryUtils::class)
         mockRevisionNumber(HASH)
+        mockFileAnnotation()
 
         every {
             GitHistoryUtils.history(
                     project,
                     virtualRoot,
-                    any(),
                     any(),
                     any(),
                     any(),
@@ -223,8 +237,8 @@ class FindPullRequestModelTest {
         } returnsMany listOf(listOf(prCommit2), listOf(prCommit3))
 
         val path = model.createPullRequestPath(gitRepository, vcsRevisionNumber)
-        assertEquals("pull/$PR_NUMBER/files", path)
-        verify(exactly = 1) { GitHistoryUtils.history(project, virtualRoot, any(), any(), any(), any(), any()) }
+        assertEquals("pull/$PR_NUMBER/files#diff-4c6e90faac2675aa89e2176d2eec7d8", path)
+        verify(exactly = 1) { GitHistoryUtils.history(project, virtualRoot, any(), any(), any(), any()) }
         verify(exactly = 2) { GitHistoryUtils.history(project, virtualRoot, any()) }
     }
 
@@ -243,7 +257,6 @@ class FindPullRequestModelTest {
             GitHistoryUtils.history(
                     project,
                     virtualRoot,
-                    any(),
                     any(),
                     any(),
                     any(),

--- a/src/test/kotlin/com/github/shiraji/model/FindPullRequestModelTest.kt
+++ b/src/test/kotlin/com/github/shiraji/model/FindPullRequestModelTest.kt
@@ -21,8 +21,9 @@ import git4idea.repo.GitRepository
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import junit.framework.TestCase.*
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class FindPullRequestModelTest {
 
@@ -74,7 +75,7 @@ class FindPullRequestModelTest {
     @MockK
     lateinit var fileAnnotation: FileAnnotation
 
-    @Before
+    @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
 
@@ -198,7 +199,7 @@ class FindPullRequestModelTest {
         assertEquals("pull/$PR_NUMBER/files#diff-4c6e90faac2675aa89e2176d2eec7d8", path)
     }
 
-    @Test(expected = NoPullRequestFoundException::class)
+    @Test
     fun `No PR found if no PR and the commit is not squash commit`() {
         val prCommit1 = generateGitCommit(hashCode = HASH, fullMessage = "Merge pull request #$PR_NUMBER from")
 
@@ -206,8 +207,9 @@ class FindPullRequestModelTest {
         mockGitRepository(listOf(generateGitRemote()))
         mockHistory(closestPRCommits = emptyList(), mergeCommits = listOf(prCommit1))
 
-        model.createPullRequestPath(gitRepository, vcsRevisionNumber)
-        fail()
+        assertThrows<NoPullRequestFoundException> {
+            model.createPullRequestPath(gitRepository, vcsRevisionNumber)
+        }
     }
 
     @Test
@@ -242,7 +244,7 @@ class FindPullRequestModelTest {
         verify(exactly = 2) { GitHistoryUtils.history(project, virtualRoot, any()) }
     }
 
-    @Test(expected = NoPullRequestFoundException::class)
+    @Test
     fun `Found PR has different hash code and its commit message is not squash commit`() {
         val prCommit1 = generateGitCommit(hashCode = HASH_DIFF, fullMessage = "Merge pull request #${PR_NUMBER} from")
         val prCommit2 = generateGitCommit(hashCode = HASH_DIFF, fullMessage = "Foo (#${PR_NUMBER})")
@@ -267,8 +269,9 @@ class FindPullRequestModelTest {
             GitHistoryUtils.history(project, virtualRoot, any())
         } returnsMany listOf(listOf(prCommit2), listOf(prCommit3))
 
-        model.createPullRequestPath(gitRepository, vcsRevisionNumber)
-        fail()
+        assertThrows<NoPullRequestFoundException> {
+            model.createPullRequestPath(gitRepository, vcsRevisionNumber)
+        }
     }
 
     @Test


### PR DESCRIPTION
Move from #58 

TODO:

- [x] Create an option for picking hosting services
- [x] Create a logic to generate commit page for each hosting services
- [x] Make sure bitbucket works for commit page
- [x] Change action name if user picks GitLab. (Merge Request is what GitLab calls)
- [x] Decide supporting squash commit for not github -> Yes -> Implemented
- [ ] Add test cases

---

NOTE Squash commit:
bitbucket has that feature. Default commit message is the same as merge commit.

```
Merged in $REPO (pull request #2)

$COMMIT
```

For gitlab, I couldn't find a feature to do squash commit