### PR TITLE
Better performance

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,8 +48,8 @@ repositories {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version = "15.0.4"
     setPlugins("github", "git4idea")
+    version = "2019.1"
     updateSinceUntilBuild = false
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,8 +48,8 @@ repositories {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    setPlugins("github", "git4idea")
     version = "2019.1"
+    setPlugins("git4idea")
     updateSinceUntilBuild = false
 }
 

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/action/BaseFindPullRequestAction.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/action/BaseFindPullRequestAction.kt
@@ -13,6 +13,7 @@ import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vcs.VcsException
@@ -63,8 +64,10 @@ abstract class BaseFindPullRequestAction : AnAction() {
 
         val hostingServices = FindPullRequestHostingServices.findBy(config.getHosting())
         try {
-            val url = "$webRepoUrl/${model.createPullRequestPath(repository, revisionHash)}"
-            actionPerform(e, url)
+            ApplicationManager.getApplication().executeOnPooledThread {
+                val url = "$webRepoUrl/${model.createPullRequestPath(repository, revisionHash)}"
+                actionPerform(e, url)
+            }
         } catch (ex: VcsException) {
             val name = FindPullRequestHostingServices.findBy(config.getHosting()).pullRequestName.toLowerCase()
             showErrorNotification("Could not find the $name for $revisionHash : ${ex.message}")

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/action/BaseFindPullRequestAction.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/action/BaseFindPullRequestAction.kt
@@ -1,6 +1,7 @@
 package com.github.shiraji.findpullrequest.action
 
 import com.github.shiraji.findpullrequest.exceptions.NoPullRequestFoundException
+import com.github.shiraji.findpullrequest.helper.root
 import com.github.shiraji.findpullrequest.helper.showErrorNotification
 import com.github.shiraji.findpullrequest.model.FindPullRequestHostingServices
 import com.github.shiraji.findpullrequest.model.FindPullRequestModel
@@ -103,7 +104,8 @@ abstract class BaseFindPullRequestAction : AnAction() {
                     val repository = manager.getRepositoryForFile(file)
                     if (repository != null) return repository
                 }
-                manager.getRepositoryForFile(project.baseDir)
+                val root = project.root ?: return null
+                manager.getRepositoryForFile(root)
             }
         }
     }

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/action/FindPullRequestCopyAction.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/action/FindPullRequestCopyAction.kt
@@ -52,7 +52,8 @@ class FindPullRequestCopyAction : BaseFindPullRequestAction() {
     override fun actionPerform(e: AnActionEvent, url: String) {
         copy(url)
 
-        val config = PropertiesComponent.getInstance(e.project)
+        val project = e.project ?: return
+        val config = PropertiesComponent.getInstance(project)
         if (config.isPopupAfterCopy())
             showInfoNotification("Copied!")
     }

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/helper/FindPullRequestHelper.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/helper/FindPullRequestHelper.kt
@@ -4,9 +4,18 @@ import com.intellij.notification.Notification
 import com.intellij.notification.NotificationListener
 import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
 
 fun showInfoNotification(message: String) =
         Notifications.Bus.notify(Notification("FindPullRequest.Info", "Find Pull Request", message, NotificationType.INFORMATION, NotificationListener.URL_OPENING_LISTENER))
 
 fun showErrorNotification(message: String) =
         Notifications.Bus.notify(Notification("FindPullRequest.Error", "Find Pull Request", message, NotificationType.ERROR))
+
+val Project.root: VirtualFile?
+        get() {
+                val basePath = basePath ?: return null
+                return LocalFileSystem.getInstance().findFileByPath(basePath) ?: return null
+        }

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/model/FindPullRequestHostingServices.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/model/FindPullRequestHostingServices.kt
@@ -1,5 +1,6 @@
 package com.github.shiraji.findpullrequest.model
 
+import com.github.shiraji.findpullrequest.helper.root
 import com.github.shiraji.subtract
 import com.github.shiraji.toMd5
 import com.github.shiraji.toSHA1
@@ -24,7 +25,7 @@ enum class FindPullRequestHostingServices(val defaultMergeCommitMessage: Regex, 
     }
 
     fun createFileAnchorValue(repository: GitRepository, annotate: FileAnnotation): String? {
-        val projectDir = repository.project.baseDir.canonicalPath?.plus("/") ?: return null
+        val projectDir = repository.project.root?.canonicalPath?.plus("/") ?: return null
         val filePath = annotate.file?.canonicalPath?.subtract(projectDir) ?: return null
         return when (this) {
             GitHub -> "#diff-${filePath.toMd5()}"

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/model/FindPullRequestHostingServices.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/model/FindPullRequestHostingServices.kt
@@ -4,14 +4,14 @@ import com.github.shiraji.findpullrequest.helper.root
 import com.github.shiraji.subtract
 import com.github.shiraji.toMd5
 import com.github.shiraji.toSHA1
+import com.intellij.icons.AllIcons
 import com.intellij.openapi.vcs.annotate.FileAnnotation
 import git4idea.repo.GitRepository
 import icons.FindPullRequestIcons
-import icons.GithubIcons
 import javax.swing.Icon
 
 enum class FindPullRequestHostingServices(val defaultMergeCommitMessage: Regex, val squashCommitMessage: Regex, val urlPathFormat: String, val commitPathFormat: String, val pullRequestName: String, val icon: Icon) {
-    GitHub("Merge pull request #(\\d*)".toRegex(), ".*\\(#(\\d*)\\)".toRegex(), "pull/%d/files", "%s/commit/%s", "Pull Request", GithubIcons.Github_icon),
+    GitHub("Merge pull request #(\\d*)".toRegex(), ".*\\(#(\\d*)\\)".toRegex(), "pull/%d/files", "%s/commit/%s", "Pull Request", AllIcons.Vcs.Vendors.Github),
     GitLab("See merge request .*!(\\d*)".toRegex(), "See merge request .*!(\\d*)".toRegex(), "merge_requests/%d/diffs", "%s/commit/%s", "Merge Request", FindPullRequestIcons.gitLabIcon),
     Bitbucket("\\(pull request #(\\d*)\\)".toRegex(), "\\(pull request #(\\d*)\\)".toRegex(), "pull-requests/%d/diff", "%s/commits/%s", "Pull Request", FindPullRequestIcons.bitbucketIcon),
 

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/model/GitConfService.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/model/GitConfService.kt
@@ -23,6 +23,6 @@ class GitConfService {
     }
 
     fun getFileAnnotation(repository: GitRepository, virtualFile: VirtualFile): FileAnnotation? {
-        return repository.vcs?.annotationProvider?.annotate(virtualFile)
+        return repository.vcs.annotationProvider.annotate(virtualFile)
     }
 }

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/model/GitHistoryService.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/model/GitHistoryService.kt
@@ -3,6 +3,7 @@ package com.github.shiraji.findpullrequest.model
 import com.github.shiraji.getNumberFromCommitMessage
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vcs.history.VcsRevisionNumber
+import com.intellij.openapi.vfs.LocalFileSystem
 import git4idea.GitCommit
 import git4idea.history.GitHistoryUtils
 import git4idea.repo.GitRepository
@@ -10,26 +11,34 @@ import git4idea.repo.GitRepository
 class GitHistoryService {
 
     fun findLatestMergeCommit(project: Project): GitCommit? {
-        val results = GitHistoryUtils.history(project, project.baseDir, "--merges")
-        return results.firstOrNull()
+        val basePath = project.basePath ?: return null
+        val root = LocalFileSystem.getInstance().findFileByPath(basePath) ?: return null
+        val commit = GitHistoryUtils.collectTimedCommits(project, root, "--merges", "-1").firstOrNull() ?: return null
+        return GitHistoryUtils.history(project, root, commit.id.asString(), "-1").firstOrNull()
     }
 
     fun findCommitLog(project: Project, repository: GitRepository, revisionHash: VcsRevisionNumber): GitCommit {
-        return GitHistoryUtils.history(project, repository.root, "$revisionHash").first()
+        return GitHistoryUtils.history(project, repository.root, "$revisionHash", "-1").first()
     }
 
     fun findMergedCommit(project: Project, repository: GitRepository, revisionHash: VcsRevisionNumber): GitCommit? {
         // See https://stackoverflow.com/questions/8475448/find-merge-commit-which-include-a-specific-commit
-        //
-        // I think there is a bug in history() since it does not keep the order correctly
-        // It seems GitLogUtil#readFullDetails is the place that store the results in list
-        val ancestryPathCommits =
-            GitHistoryUtils.history(project, repository.root, "$revisionHash..HEAD", "--merges", "--ancestry-path")
-                .sortedBy { it.commitTime }
-        val firstParentsCommits =
-            GitHistoryUtils.history(project, repository.root, "$revisionHash..HEAD", "--merges", "--first-parent")
-                .sortedBy { it.commitTime }
-        return ancestryPathCommits.firstOrNull { firstParentsCommits.contains(it) }
+        val ancestryPathCommits = GitHistoryUtils.collectTimedCommits(
+            project,
+            repository.root,
+            "$revisionHash..HEAD",
+            "--merges",
+            "--ancestry-path"
+        )
+        val firstParentsCommits = GitHistoryUtils.collectTimedCommits(
+            project,
+            repository.root,
+            "$revisionHash..HEAD",
+            "--merges",
+            "--first-parent"
+        )
+        val commit = ancestryPathCommits.lastOrNull { firstParentsCommits.contains(it) } ?: return null
+        return GitHistoryUtils.history(project, repository.root, commit.id.asString(), "-1").firstOrNull()
     }
 
     fun listCommitsFromMergedCommit(project: Project, repository: GitRepository, pullRequestCommit: GitCommit): List<GitCommit> {

--- a/src/test/kotlin/com/github/shiraji/findpullrequest/model/FindPullRequestHostingServicesTest.kt
+++ b/src/test/kotlin/com/github/shiraji/findpullrequest/model/FindPullRequestHostingServicesTest.kt
@@ -1,11 +1,16 @@
 package com.github.shiraji.findpullrequest.model
 
+import com.github.shiraji.findpullrequest.helper.root
 import com.github.shiraji.subtract
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.vcs.annotate.FileAnnotation
+import com.intellij.openapi.vfs.LocalFileSystem
 import git4idea.repo.GitRepository
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -13,12 +18,20 @@ class FindPullRequestHostingServicesTest {
 
     @Nested
     inner class createFileAnchorValue {
+        val project: Project = mockk()
+        val repository: GitRepository = mockk()
+
+        @BeforeEach
+        fun setUp() {
+            mockkStatic(LocalFileSystem::class)
+            every { LocalFileSystem.getInstance().findFileByPath(any()) } returns null
+            every { project.basePath } returns ""
+            every { project.root?.canonicalPath } returns ""
+            every { repository.project } returns project
+        }
+
         @Test
         fun `Should create GitHub style of file anchor`() {
-
-            val repository: GitRepository = mockk()
-            every { repository.project.baseDir.canonicalPath } returns ""
-
             val annotate: FileAnnotation = mockk()
             every { annotate.file?.canonicalPath?.subtract("") } returns "aaa"
 
@@ -29,10 +42,6 @@ class FindPullRequestHostingServicesTest {
 
         @Test
         fun `Should create GitLab style of file anchor`() {
-
-            val repository: GitRepository = mockk()
-            every { repository.project.baseDir.canonicalPath } returns ""
-
             val annotate: FileAnnotation = mockk()
             every { annotate.file?.canonicalPath?.subtract("") } returns "aaa"
 
@@ -43,10 +52,6 @@ class FindPullRequestHostingServicesTest {
 
         @Test
         fun `Should create Bitbucket style of file anchor`() {
-
-            val repository: GitRepository = mockk()
-            every { repository.project.baseDir.canonicalPath } returns ""
-
             val annotate: FileAnnotation = mockk()
             every { annotate.file?.canonicalPath?.subtract("") } returns "aaa"
 


### PR DESCRIPTION
* Because git4idea plugin, from this PR, this plugin requires IntelliJ 2019.1 or higher. See #45
* This plugin won't depend on github plugin anymore (The official IntelliJ provides us GitHub icon)
* Use background thread while finding PR
* Fix the startup problem with the repo that contains a lot of commits. See #105 