### PR TITLE
List PR

### DIFF
--- a/src/main/kotlin/com/github/shiraji/findpullrequest/action/ListPullRequestToggleAction.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/action/ListPullRequestToggleAction.kt
@@ -1,0 +1,150 @@
+package com.github.shiraji.findpullrequest.action
+
+import com.github.shiraji.findpullrequest.annotation.ListPullRequestTextAnnotationGutterProvider
+import com.github.shiraji.findpullrequest.domain.GitPullRequestInfo
+import com.github.shiraji.findpullrequest.helper.root
+import com.github.shiraji.findpullrequest.model.FindPullRequestHostingServices
+import com.github.shiraji.findpullrequest.model.FindPullRequestModel
+import com.github.shiraji.findpullrequest.model.GitConfService
+import com.github.shiraji.findpullrequest.model.GitHistoryService
+import com.github.shiraji.findpullrequest.model.GitRepositoryUrlService
+import com.github.shiraji.findpullrequest.model.getHosting
+import com.github.shiraji.getNumberFromCommitMessage
+import com.github.shiraji.isSquashPullRequestCommit
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.ToggleAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.ex.EditorGutterComponentEx
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.vcs.ProjectLevelVcsManager
+import com.intellij.openapi.vcs.VcsException
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.ui.UIUtil
+import git4idea.GitRevisionNumber
+import git4idea.GitUtil
+import git4idea.repo.GitRepository
+
+class ListPullRequestToggleAction : ToggleAction() {
+
+    override fun isSelected(e: AnActionEvent): Boolean {
+        val editor: Editor = e.getData(CommonDataKeys.EDITOR) ?: return false
+        val virtualFile: VirtualFile = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return false
+        val gutter = editor.gutter as? EditorGutterComponentEx ?: return false
+        return gutter.textAnnotations.filterIsInstance(ListPullRequestTextAnnotationGutterProvider::class.java).firstOrNull {
+            it.virtualFile.path == virtualFile.path
+        } != null
+    }
+
+    override fun setSelected(e: AnActionEvent, state: Boolean) {
+        if (state) {
+            listPRs(e)
+        } else {
+            val editor: Editor = e.getData(CommonDataKeys.EDITOR) ?: return
+            // IntelliJ's limitation. I mean, I think I can close only this plugin's annotation but let's wait they support closing each annotation.
+            editor.gutter.closeAllAnnotations()
+        }
+    }
+
+    private fun listPRs(e: AnActionEvent) {
+        val project: Project = e.getData(CommonDataKeys.PROJECT) ?: return
+        val editor: Editor = e.getData(CommonDataKeys.EDITOR) ?: return
+        val config: PropertiesComponent = PropertiesComponent.getInstance(project)
+        val virtualFile: VirtualFile = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
+        val repository = getGitRepository(project, virtualFile) ?: return
+        val gitHistoryService = GitHistoryService()
+        val revisionHashes = gitHistoryService.findRevisionHashes(project, repository, virtualFile)
+        val gitRepositoryService = GitConfService()
+        val gitUrlService = GitRepositoryUrlService()
+        val model = FindPullRequestModel(project, editor, virtualFile, gitRepositoryService, gitUrlService, gitHistoryService)
+        val map = hashMapOf<String, GitPullRequestInfo>()
+        val fileAnnotation = GitConfService().getFileAnnotation(repository, virtualFile) ?: return
+        fileAnnotation.setCloser {
+            UIUtil.invokeLaterIfNeeded {
+                if (!project.isDisposed) editor.gutter.closeAllAnnotations()
+            }
+        }
+        fileAnnotation.setReloader { newFileAnnotation ->
+            println(newFileAnnotation)
+        }
+
+        if (fileAnnotation.isClosed) return
+
+        val disposable = Disposable { fileAnnotation.dispose() }
+
+        if (fileAnnotation.file != null && fileAnnotation.file!!.isInLocalFileSystem) {
+            val changesListener = ProjectLevelVcsManager.getInstance(project).annotationLocalChangesListener
+            changesListener.registerAnnotation(fileAnnotation.file, fileAnnotation)
+            Disposer.register(disposable, Disposable {
+                    changesListener.unregisterAnnotation(fileAnnotation.file, fileAnnotation)
+            })
+        }
+
+        // Not sure why but fileAnnotation.revisions does not return local commits.
+        // To resolve that, this plugin uses gitHistoryService.findRevisionHashes() to list all hashes of current file
+        revisionHashes.distinct().forEach { hash ->
+            if (map.containsKey(hash)) return@forEach
+            val revisionNumber = try {
+                GitRevisionNumber.resolve(project, repository.root, hash)
+            } catch (e: VcsException) {
+                return@forEach
+            }
+            val pullRequestCommit = gitHistoryService.findMergedCommit(project, repository, revisionNumber)
+            val pair = if (pullRequestCommit != null && gitHistoryService.hasCommitsFromRevisionNumber(
+                    gitHistoryService.listCommitsFromMergedCommit(
+                        project,
+                        repository,
+                        pullRequestCommit
+                    ), revisionNumber
+                )
+            ) {
+                val hosting = FindPullRequestHostingServices.findBy(config.getHosting())
+                val prNumberUsingConfig =
+                    pullRequestCommit.getNumberFromCommitMessage(hosting.defaultMergeCommitMessage)
+
+                if (prNumberUsingConfig == null) {
+                    // Check if the merge commit message comes from other supporting hosting service
+                    gitHistoryService.findPrNumberAndHostingService(pullRequestCommit)
+                } else {
+                    Pair(prNumberUsingConfig, hosting)
+                }
+            } else {
+                val commit = gitHistoryService.findCommitLog(project, repository, revisionNumber)
+                val hostingServices = FindPullRequestHostingServices.values().firstOrNull {
+                    commit.isSquashPullRequestCommit(it)
+                }
+
+                if (hostingServices != null) {
+                    Pair(commit.getNumberFromCommitMessage(hostingServices.squashCommitMessage), hostingServices)
+                } else {
+                    Pair(null, FindPullRequestHostingServices.findBy(config.getHosting()))
+                }
+            }
+
+            map[hash] = GitPullRequestInfo(prNumber = pair.first, revisionNumber = revisionNumber, hostingServices = pair.second)
+        }
+
+        val provider = ListPullRequestTextAnnotationGutterProvider(map, virtualFile, fileAnnotation, model, repository)
+        editor.gutter.registerTextAnnotation(provider, provider)
+    }
+
+    private fun getGitRepository(project: Project, file: VirtualFile?): GitRepository? {
+        val manager = GitUtil.getRepositoryManager(project)
+        val repositories = manager.repositories
+        return when (repositories.size) {
+            0 -> null
+            1 -> repositories[0]
+            else -> {
+                if (file != null) {
+                    val repository = manager.getRepositoryForFile(file)
+                    if (repository != null) return repository
+                }
+                val root = project.root ?: return null
+                manager.getRepositoryForFile(root)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/annotation/ListPullRequestTextAnnotationGutterProvider.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/annotation/ListPullRequestTextAnnotationGutterProvider.kt
@@ -1,0 +1,81 @@
+package com.github.shiraji.findpullrequest.annotation
+
+import com.github.shiraji.findpullrequest.domain.GitPullRequestInfo
+import com.github.shiraji.findpullrequest.model.FindPullRequestModel
+import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorGutterAction
+import com.intellij.openapi.editor.TextAnnotationGutterProvider
+import com.intellij.openapi.editor.colors.ColorKey
+import com.intellij.openapi.editor.colors.EditorColors
+import com.intellij.openapi.editor.colors.EditorFontType
+import com.intellij.openapi.vcs.annotate.FileAnnotation
+import com.intellij.openapi.vcs.impl.UpToDateLineNumberProviderImpl
+import com.intellij.openapi.vfs.VirtualFile
+import git4idea.repo.GitRepository
+import java.awt.Color
+import java.awt.Cursor
+
+class ListPullRequestTextAnnotationGutterProvider constructor(
+    private val gitHashesMap: HashMap<String, GitPullRequestInfo>,
+    val virtualFile: VirtualFile,
+    private val fileAnnotation: FileAnnotation,
+    private val model: FindPullRequestModel,
+    private val repository: GitRepository
+) : TextAnnotationGutterProvider, EditorGutterAction {
+
+    override fun getPopupActions(line: Int, editor: Editor?): MutableList<AnAction> {
+        return mutableListOf()
+    }
+
+    override fun getColor(line: Int, editor: Editor?): ColorKey? {
+        return EditorColors.ANNOTATIONS_COLOR
+    }
+
+    override fun getLineText(line: Int, editor: Editor?): String? {
+        val upToDateLineNumberProvider = UpToDateLineNumberProviderImpl(editor?.document, editor?.project)
+        val currentLine = upToDateLineNumberProvider.getLineNumber(line)
+        if (currentLine < 0) return ""
+        val hash = fileAnnotation.getLineRevisionNumber(currentLine)?.asString() ?: ""
+        val prNumber = gitHashesMap[hash]?.prNumber
+        return if (prNumber != null) "#$prNumber" else gitHashesMap[hash]?.revisionNumber?.shortRev
+    }
+
+    override fun getToolTip(line: Int, editor: Editor?): String? {
+        return null
+    }
+
+    override fun getStyle(line: Int, editor: Editor?): EditorFontType {
+        return EditorFontType.PLAIN
+    }
+
+    override fun getBgColor(line: Int, editor: Editor?): Color? {
+        return null
+    }
+
+    override fun gutterClosed() {
+    }
+
+    override fun doAction(lineNum: Int) {
+        val hash = fileAnnotation.getLineRevisionNumber(lineNum)?.asString() ?: ""
+        val gitPullRequestInfo = gitHashesMap[hash] ?: return
+        val hostingService = gitPullRequestInfo.hostingServices ?: return
+        val webRepoUrl = model.createWebRepoUrl(repository) ?: return
+
+        if (gitPullRequestInfo.prNumber == null) {
+            val url = model.createCommitUrl(repository, hostingService, webRepoUrl, gitPullRequestInfo.revisionNumber)
+
+            BrowserUtil.open(url)
+        } else {
+            val path = hostingService.urlPathFormat.format(gitPullRequestInfo.prNumber)
+            val url = model.createUrl(repository, hostingService, path)
+
+            BrowserUtil.open("$webRepoUrl/$url")
+        }
+    }
+
+    override fun getCursor(lineNum: Int): Cursor {
+        return Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+    }
+}

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/domain/GitPullRequestInfo.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/domain/GitPullRequestInfo.kt
@@ -1,0 +1,10 @@
+package com.github.shiraji.findpullrequest.domain
+
+import com.github.shiraji.findpullrequest.model.FindPullRequestHostingServices
+import git4idea.GitRevisionNumber
+
+data class GitPullRequestInfo(
+    val revisionNumber: GitRevisionNumber,
+    val prNumber: Int?,
+    val hostingServices: FindPullRequestHostingServices?
+)

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/model/FindPullRequestModel.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/model/FindPullRequestModel.kt
@@ -84,7 +84,7 @@ class FindPullRequestModel(
         }
     }
 
-    private fun createUrl(repository: GitRepository, hostingServices: FindPullRequestHostingServices, path: String): String {
+    fun createUrl(repository: GitRepository, hostingServices: FindPullRequestHostingServices, path: String): String {
         return if (config.isJumpToFile()) {
             val fileAnnotation = gitConfService.getFileAnnotation(repository, virtualFile) ?: return path
             path + hostingServices.createFileAnchorValue(repository, fileAnnotation)

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/model/GitHistoryService.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/model/GitHistoryService.kt
@@ -66,7 +66,7 @@ class GitHistoryService {
     }
 
     @Throws(VcsException::class)
-    fun findRevisionHash(project: Project, repository: GitRepository, virtualFile: VirtualFile, lineNumber: Int): GitRevisionNumber {
+    fun findRevisionHashes(project: Project, repository: GitRepository, virtualFile: VirtualFile): List<String> {
         val filePath = VcsUtil.getLastCommitPath(project, VcsUtil.getFilePath(virtualFile))
         val handler = GitBinaryHandler(project, repository.root, GitCommand.BLAME)
         handler.setStdoutSuppressed(true)
@@ -74,7 +74,13 @@ class GitHistoryService {
         handler.endOptions()
         handler.addRelativePaths(filePath)
         val output = String(handler.run(), StandardCharsets.UTF_8)
-        val revisionString = output.split("\n")[lineNumber].split(Regex("\\s"))[0]
+        return output.split("\n").map { it.split(Regex("\\s"))[0] }
+    }
+
+    @Throws(VcsException::class)
+    fun findRevisionHash(project: Project, repository: GitRepository, virtualFile: VirtualFile, lineNumber: Int): GitRevisionNumber {
+        val revisions = findRevisionHashes(project, repository, virtualFile)
+        val revisionString = revisions[lineNumber]
         return GitRevisionNumber.resolve(project, repository.root, revisionString)
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -35,6 +35,11 @@
             icon="AllIcons.Actions.Copy">
       <add-to-group group-id="EditorPopupMenu" anchor="after" relative-to-action="com.github.shiraji.findpullrequest.action.FindPullRequestAction"/>
     </action>
+
+    <action id="com.github.shiraji.findpullrequest.action.ListPullRequestToggleAction"
+            class="com.github.shiraji.findpullrequest.action.ListPullRequestToggleAction" text="List Pull Requests" description="List the pull request for each line.">
+      <add-to-group group-id="EditorGutterVcsPopupMenu" relative-to-action="Annotate" anchor="after"/>
+    </action>
   </actions>
 
 </idea-plugin>


### PR DESCRIPTION
See #113 

TODO: 
- [x] List PR
- [x] Keep PR number (should be same behavior as Annotate)
- [x] List commit hash if PR number not found
- [x] Open PR URL
- [x] Open Commit URL
- [x] Keep open if user add/delete lines

NOT in this version
* Store hash/pr map
* Refactor
* Add tests
* Close only "List PR" -> I think there is no open API for this function. Need to raise issue.
* Show error if file line number is not the same as git's result (e.g. https://github.com/shiraji/conference-app-2019/blob/master/dependencies.kts)