### PR TITLE
Use short name if the action is not EDITOR_POPUP

### DIFF
--- a/src/main/kotlin/com/github/shiraji/findpullrequest/action/BaseFindPullRequestAction.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/action/BaseFindPullRequestAction.kt
@@ -11,6 +11,7 @@ import com.github.shiraji.findpullrequest.model.GitRepositoryUrlService
 import com.github.shiraji.findpullrequest.model.getHosting
 import com.github.shiraji.getLine
 import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.actionSystem.ActionPlaces
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -30,7 +31,7 @@ abstract class BaseFindPullRequestAction : AnAction() {
 
     abstract fun actionPerform(e: AnActionEvent, url: String)
 
-    abstract fun menuText(project: Project): String?
+    abstract fun menuText(project: Project, useShortName: Boolean): String?
 
     private fun menuIcon(project: Project): Icon? {
         val config = PropertiesComponent.getInstance(project) ?: return null
@@ -94,7 +95,8 @@ abstract class BaseFindPullRequestAction : AnAction() {
         val editor: Editor = e.getData(CommonDataKeys.EDITOR) ?: return
         val virtualFile: VirtualFile = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
         val repository = getGitRepository(project, virtualFile) ?: return
-        val text = menuText(project) ?: return
+        val useShortName = ActionPlaces.EDITOR_POPUP == e.place
+        val text = menuText(project, useShortName) ?: return
         val icon = menuIcon(project)
         val description = description(project, editor, virtualFile)
         val gitRepositoryService = GitConfService()

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/action/FindPullRequestAction.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/action/FindPullRequestAction.kt
@@ -20,7 +20,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import java.net.URLEncoder
 import java.util.Locale
-import javax.swing.Icon
 
 class FindPullRequestAction : BaseFindPullRequestAction() {
     override fun actionPerformForNoPullRequestFount(e: AnActionEvent, ex: NoPullRequestFoundException, url: String) {
@@ -46,9 +45,13 @@ class FindPullRequestAction : BaseFindPullRequestAction() {
         BrowserUtil.open(url)
     }
 
-    override fun menuText(project: Project): String? {
+    override fun menuText(project: Project, useShortName: Boolean): String? {
         val config = PropertiesComponent.getInstance(project) ?: return null
-        return FindPullRequestHostingServices.findBy(config.getHosting()).pullRequestName
+        return if (useShortName) {
+            FindPullRequestHostingServices.findBy(config.getHosting()).pullRequestName
+        } else {
+            "Go to ${FindPullRequestHostingServices.findBy(config.getHosting()).pullRequestName} page"
+        }
     }
 
     override fun description(project: Project, editor: Editor, virtualFile: VirtualFile): String? {

--- a/src/main/kotlin/com/github/shiraji/findpullrequest/action/FindPullRequestCopyAction.kt
+++ b/src/main/kotlin/com/github/shiraji/findpullrequest/action/FindPullRequestCopyAction.kt
@@ -22,7 +22,6 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.ui.TextTransferable
 import java.net.URLEncoder
 import java.util.Locale
-import javax.swing.Icon
 import javax.swing.event.HyperlinkEvent
 
 class FindPullRequestCopyAction : BaseFindPullRequestAction() {
@@ -72,9 +71,13 @@ class FindPullRequestCopyAction : BaseFindPullRequestAction() {
         CopyPasteManager.getInstance().setContents(TextTransferable(text as CharSequence))
     }
 
-    override fun menuText(project: Project): String? {
+    override fun menuText(project: Project, useShortName: Boolean): String? {
         val config = PropertiesComponent.getInstance(project) ?: return null
-        return "Copy Link to ${FindPullRequestHostingServices.findBy(config.getHosting()).pullRequestName}"
+        return if (useShortName) {
+            "Copy Link to ${FindPullRequestHostingServices.findBy(config.getHosting()).pullRequestName}"
+        } else {
+            "Copy Link to ${FindPullRequestHostingServices.findBy(config.getHosting()).pullRequestName} URL"
+        }
     }
 
     override fun description(project: Project, editor: Editor, virtualFile: VirtualFile): String? {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -42,22 +42,30 @@
   </applicationListeners>
 
   <actions>
+    <!-- text will be replaced in the action -->
+    <!-- Find Action somehow cache this text for searching the action, therefore, we put both pull request/merge request here for all users -->
     <action id="com.github.shiraji.findpullrequest.action.FindPullRequestAction"
             class="com.github.shiraji.findpullrequest.action.FindPullRequestAction"
-            text="Find Pull Request"
+            text="Find Pull Request/Merge Request"
             icon="AllIcons.Vcs.Vendors.Github">
+      <!--suppress PluginXmlCapitalization -->
+      <synonym text="find go to merge pull request github gitlab bitbucket page" />
       <add-to-group group-id="RevealGroup" anchor="after" relative-to-action="Github.Open.In.Browser"/>
     </action>
 
     <action id="com.github.shiraji.findpullrequest.action.FindPullRequestCopyAction"
             class="com.github.shiraji.findpullrequest.action.FindPullRequestCopyAction"
-            text="Copy Link to Pull Request URL"
+            text="Copy Link to Pull Request/Merge Request URL"
             icon="AllIcons.Vcs.Vendors.Github">
+      <!--suppress PluginXmlCapitalization -->
+      <synonym text="copy link to merge pull request github gitlab bitbucket url" />
       <add-to-group group-id="Copy.Paste.Special" anchor="before" relative-to-action="EditorPasteSimple" />
     </action>
 
     <action id="com.github.shiraji.findpullrequest.action.ListPullRequestToggleAction"
-            class="com.github.shiraji.findpullrequest.action.ListPullRequestToggleAction" text="List Pull Requests" description="List the pull request for each line.">
+            class="com.github.shiraji.findpullrequest.action.ListPullRequestToggleAction"
+            text="List Pull Requests/Merge Requests"
+            description="List the pull request for each line.">
       <add-to-group group-id="EditorGutterVcsPopupMenu" relative-to-action="Annotate" anchor="after"/>
     </action>
   </actions>

--- a/src/test/kotlin/com/github/shiraji/findpullrequest/action/FindPullRequestActionTest.kt
+++ b/src/test/kotlin/com/github/shiraji/findpullrequest/action/FindPullRequestActionTest.kt
@@ -1,0 +1,69 @@
+package com.github.shiraji.findpullrequest.action
+
+import com.github.shiraji.findpullrequest.model.FindPullRequestHostingServices
+import com.github.shiraji.findpullrequest.model.getHosting
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.command.impl.DummyProject
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+class FindPullRequestActionTest {
+
+    private val action = FindPullRequestAction()
+
+    @Suppress("unused")
+    enum class MenuTextTest(
+        val config: PropertiesComponent?,
+        val useShortName: Boolean,
+        val hosting: String,
+        val expected: String?,
+        private val testName: String,
+    ) {
+        C1(null, true, "GitHub", null, "Should return null when PropertiesComponent is null"),
+        C2(mockk(), true, "GitHub", FindPullRequestHostingServices.GitHub.pullRequestName, "Should return short name if useShortName is true"),
+        C3(mockk(), true, "Bitbucket", FindPullRequestHostingServices.Bitbucket.pullRequestName, "Should return short name if useShortName is true for Bitbucket"),
+        C4(mockk(), true, "GitLab", FindPullRequestHostingServices.GitLab.pullRequestName, "Should return short name if useShortName is true for GitLab"),
+        C5(mockk(), true, "", FindPullRequestHostingServices.GitHub.pullRequestName, "Should return GitHub's short name if hosting is invalid value"),
+        C6(mockk(), false, "GitHub", "Go to ${FindPullRequestHostingServices.GitHub.pullRequestName} page", "Should return long name if useShortName is false"),
+        C7(mockk(), false, "Bitbucket", "Go to ${FindPullRequestHostingServices.Bitbucket.pullRequestName} page", "Should return short name if useShortName is false for Bitbucket"),
+        C8(mockk(), false, "GitLab", "Go to ${FindPullRequestHostingServices.GitLab.pullRequestName} page", "Should return short name if useShortName is false for GitLab"),
+        C9(mockk(), false, "", "Go to ${FindPullRequestHostingServices.GitHub.pullRequestName} page", "Should return GitHub's short name if hosting is invalid value"),
+
+        ;
+
+        override fun toString(): String {
+            return testName
+        }
+    }
+
+    @Nested
+    inner class menuText {
+
+
+        @BeforeEach
+        fun setUp() {
+            mockkStatic(PropertiesComponent::class)
+        }
+
+        @ParameterizedTest
+        @EnumSource(MenuTextTest::class)
+        fun `Test menuText`(test: MenuTextTest) {
+            every { PropertiesComponent.getInstance(any()) } returns test.config
+            if (test.config != null) {
+                every { test.config.getHosting() } returns test.hosting
+            }
+            val result = action.menuText(DummyProject.getInstance(), test.useShortName)
+            if (test.expected == null) {
+                assertNull(result)
+            } else {
+                assert(result == test.expected)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/github/shiraji/findpullrequest/action/FindPullRequestCopyActionTest.kt
+++ b/src/test/kotlin/com/github/shiraji/findpullrequest/action/FindPullRequestCopyActionTest.kt
@@ -1,0 +1,67 @@
+package com.github.shiraji.findpullrequest.action
+
+import com.github.shiraji.findpullrequest.model.FindPullRequestHostingServices
+import com.github.shiraji.findpullrequest.model.getHosting
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.command.impl.DummyProject
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+class FindPullRequestCopyActionTest {
+    private val action = FindPullRequestCopyAction()
+
+    @Suppress("unused")
+    enum class MenuTextTest(
+        val config: PropertiesComponent?,
+        val useShortName: Boolean,
+        val hosting: String,
+        val expected: String?,
+        private val testName: String,
+    ) {
+        C1(null, true, "GitHub", null, "Should return null when PropertiesComponent is null"),
+        C2(mockk(), true, "GitHub", "Copy Link to ${FindPullRequestHostingServices.GitHub.pullRequestName}", "Should return short name if useShortName is true"),
+        C3(mockk(), true, "Bitbucket", "Copy Link to ${FindPullRequestHostingServices.Bitbucket.pullRequestName}", "Should return short name if useShortName is true for Bitbucket"),
+        C4(mockk(), true, "GitLab", "Copy Link to ${FindPullRequestHostingServices.GitLab.pullRequestName}", "Should return short name if useShortName is true for GitLab"),
+        C5(mockk(), true, "", "Copy Link to ${FindPullRequestHostingServices.GitHub.pullRequestName}", "Should return GitHub's short name if hosting is invalid value"),
+        C6(mockk(), false, "GitHub", "Copy Link to ${FindPullRequestHostingServices.GitHub.pullRequestName} URL", "Should return long name if useShortName is false"),
+        C7(mockk(), false, "Bitbucket", "Copy Link to ${FindPullRequestHostingServices.Bitbucket.pullRequestName} URL", "Should return short name if useShortName is false for Bitbucket"),
+        C8(mockk(), false, "GitLab", "Copy Link to ${FindPullRequestHostingServices.GitLab.pullRequestName} URL", "Should return short name if useShortName is false for GitLab"),
+        C9(mockk(), false, "", "Copy Link to ${FindPullRequestHostingServices.GitHub.pullRequestName} URL", "Should return GitHub's short name if hosting is invalid value"),
+
+        ;
+
+        override fun toString(): String {
+            return testName
+        }
+    }
+
+    @Nested
+    inner class menuText {
+
+        @BeforeEach
+        fun setUp() {
+            mockkStatic(PropertiesComponent::class)
+        }
+
+        @ParameterizedTest
+        @EnumSource(MenuTextTest::class)
+        fun `Test menuText`(test: MenuTextTest) {
+            every { PropertiesComponent.getInstance(any()) } returns test.config
+            if (test.config != null) {
+                every { test.config.getHosting() } returns test.hosting
+            }
+            val result = action.menuText(DummyProject.getInstance(), test.useShortName)
+            if (test.expected == null) {
+                Assertions.assertNull(result)
+            } else {
+                assert(result == test.expected)
+            }
+        }
+    }
+}


### PR DESCRIPTION
see: #157 

![image](https://github.com/shiraji/find-pull-request/assets/3675458/26af08b3-6c96-47e9-91a9-c316eaba487f)

![image](https://github.com/shiraji/find-pull-request/assets/3675458/6938889c-127b-4238-ae66-6f933492b00b)
![image](https://github.com/shiraji/find-pull-request/assets/3675458/60e93628-6342-4d50-a458-8a5e99dc3fd3)

right click menu isn't changed
![image](https://github.com/shiraji/find-pull-request/assets/3675458/a38b7b35-312c-45a0-81ed-9eed3cf271af)

